### PR TITLE
Update chiselled jre tests to use Java 17

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Tests PDFBox
         uses: actions/cache@v3
         with:
-          path: tests/pdfbox/pdfbox-3.0.0-alpha3
+          path: tests/pdfbox/pdfbox
           key: tests-pdfbox-pdfbox-3.0.0-alpha3
           restore-keys: |
             tests-pdfbox-pdfbox-3.0.0-alpha3

--- a/demos/petclinic/Dockerfile
+++ b/demos/petclinic/Dockerfile
@@ -7,9 +7,9 @@ ARG UID=101
 ARG GROUP=app
 ARG GID=101
 
-FROM eclipse-temurin:8u362-b09-jdk-jammy as builder
+FROM eclipse-temurin:17-jdk-jammy as builder
 
-ENV PETCLINIC_TAG=${PETCLINIC_TAG:-spring-boot-2.7.3}
+ENV PETCLINIC_TAG=${PETCLINIC_TAG:-spring-boot-3.0.6}
 ENV PETCLINIC_REPO=${PETCLINIC_REPO:-https://github.com/vpa1977/spring-petclinic}
 
 RUN apt-get update \
@@ -28,10 +28,10 @@ USER $UID:$GID
 
 # copy petclinic sample
 COPY --chown=$UID:$GID --from=builder \
-    /spring-petclinic/target/spring-petclinic-2.7.3.jar /
+    /spring-petclinic/target/spring-petclinic-3.0.6.jar /
 
 WORKDIR /
 
-ENTRYPOINT ["/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java", \
+ENTRYPOINT ["/opt/java/bin/java", \
     "-jar", \
-    "spring-petclinic-2.7.3.jar" ]
+    "spring-petclinic-3.0.6.jar" ]

--- a/jre/Dockerfile.22.04
+++ b/jre/Dockerfile.22.04
@@ -6,7 +6,7 @@ ARG GID=101
 
 FROM golang:1.20 AS chisel
 ARG UBUNTU_RELEASE
-RUN git clone -b jre17-mandatory https://github.com/vpa1977/chisel-releases /opt/chisel-releases \
+RUN git clone -b jre17-dependencies-functional https://github.com/vpa1977/chisel-releases /opt/chisel-releases \
     && git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \

--- a/jre/Dockerfile.22.04
+++ b/jre/Dockerfile.22.04
@@ -6,7 +6,7 @@ ARG GID=101
 
 FROM golang:1.20 AS chisel
 ARG UBUNTU_RELEASE
-RUN git clone -b jre17-dependencies-functional https://github.com/vpa1977/chisel-releases /opt/chisel-releases \
+RUN git clone -b jre17-mandatory https://github.com/vpa1977/chisel-releases /opt/chisel-releases \
     && git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \

--- a/tests/acmeair/runtest
+++ b/tests/acmeair/runtest
@@ -17,7 +17,7 @@ fi
 
 TEST_DIR=`pwd`
 PROJECT=acmeair-monolithic-java
-TAG=chiselled-test-mongo
+TAG=chiselled-demo-17
 ACMEAIR_REPO=https://github.com/vpa1977/${PROJECT}
 
 DOCKER_OPTS="--rm  \

--- a/tests/pdfbox/Dockerfile
+++ b/tests/pdfbox/Dockerfile
@@ -31,11 +31,12 @@ ARG GROUP
 ARG GID
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 COPY --from=chisel /opt/chisel-releases /opt/chisel-releases
-# use Java 8 headless AWT depedendencies
-
 RUN mkdir -p /rootfs \
       && chisel cut --release /opt/chisel-releases --root /rootfs \
-        openjdk-8-jre-headless_awt
+        liblcms2-2_libs \
+        libfontconfig1_libs \
+        libfreetype6_libs \
+        libjpeg-turbo8_libs
 
 FROM $MAVEN_IMAGE
 COPY --from=sliced-deps /rootfs /

--- a/tests/pdfbox/Dockerfile
+++ b/tests/pdfbox/Dockerfile
@@ -7,7 +7,7 @@ ARG GID=101
 
 FROM golang:1.20 AS chisel
 ARG UBUNTU_RELEASE
-RUN git clone https://github.com/canonical/chisel-releases /opt/chisel-releases \
+RUN git clone --depth 1 -b ubuntu-22.04 https://github.com/canonical/chisel-releases /opt/chisel-releases \
     && git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \

--- a/tests/pdfbox/runtest
+++ b/tests/pdfbox/runtest
@@ -16,8 +16,8 @@ if [ -z $M2_CACHE ]; then
     exit 1
 fi
 
-VERSION=3.0.0-alpha3-patch
-
+PDFBOX_REPO=https://github.com/vpa1977/pdfbox
+VERSION=3.0.0-alpha3
 APP=pdfbox
 TEST_DIR=`pwd`
 
@@ -30,9 +30,10 @@ DOCKER_OPTS="--rm  \
     -v ${TEST_DIR}:${TEST_DIR} \
     -w ${TEST_DIR}/${APP} "
 
-if [ ! -d ${APP} ]; then
-    git clone -b ${VERSION} https://github.com/vpa1977/pdfbox
-fi
+git clone --branch ${VERSION} ${PDFBOX_REPO} || \
+    (cd ${APP} && \
+     git checkout ${VERSION} &&
+     git reset --hard)
 
 # build and tests with chiselled jre
 docker run \

--- a/tests/petclinic-test/Dockerfile
+++ b/tests/petclinic-test/Dockerfile
@@ -1,5 +1,0 @@
-ARG BASE_IMAGE=ubuntu/jre:17_edge
-FROM $BASE_IMAGE
-# shell is needed for maven surefire plugin
-ADD sh /bin/sh
-

--- a/tests/petclinic-test/runtest
+++ b/tests/petclinic-test/runtest
@@ -18,7 +18,7 @@ fi
 
 # clone petclinic repository, alternative is to have a submodule here
 TEST_DIR=`pwd`
-APP=spring-petclinic
+PROJECT=spring-petclinic
 
 PETCLINIC_TAG=spring-boot-3.0.6
 PETCLINIC_REPO=https://github.com/vpa1977/${PROJECT}
@@ -34,7 +34,7 @@ DOCKER_OPTS="--rm  \
     -u app \
     -v ${M2_CACHE}:${M2_CACHE} \
     -v ${TEST_DIR}:${TEST_DIR} \
-    -w ${TEST_DIR}/${APP} "
+    -w ${TEST_DIR}/${PROJECT} "
 
 # now run the tests within our container
 docker run \

--- a/tests/petclinic-test/runtest
+++ b/tests/petclinic-test/runtest
@@ -1,18 +1,13 @@
 #!/bin/bash
 set -ex
 
-# This test builds tests for spring-petclinic with Maven, copies class files
-# into the chiselled container and executes them in the container environemnt.
+# This test builds and runs tests for spring-petclinic using Maven inside
+# chiselled JRE container
 
 echo "Running Spring Petclinic self-tests"
 
-if [ -z $BUILD_IMAGE ]; then
-    echo 'Please define $BUILD_IMAGE'
-    exit 1
-fi
-
-if [ -z $BASE_IMAGE ]; then
-    echo 'Please define $BASE_IMAGE'
+if [ -z $MAVEN_IMAGE ]; then
+    echo 'Please define $MAVEN_IMAGE'
     exit 1
 fi
 
@@ -23,47 +18,27 @@ fi
 
 # clone petclinic repository, alternative is to have a submodule here
 TEST_DIR=`pwd`
-PROJECT=spring-petclinic
-PROJECT_DIR=${TEST_DIR}/${PROJECT}
+APP=spring-petclinic
 
-PETCLINIC_TAG=spring-boot-2.7.3
+PETCLINIC_TAG=spring-boot-3.0.6
 PETCLINIC_REPO=https://github.com/vpa1977/${PROJECT}
-echo cloning $PETCLINIC_TAG $PETCLINIC_REPO
-git clone --branch $PETCLINIC_TAG $PETCLINIC_REPO || \
+echo cloning ${PETCLINIC_TAG} ${PETCLINIC_REPO}
+git clone --branch ${PETCLINIC_TAG} ${PETCLINIC_REPO} || \
     (cd ${PROJECT} && \
      git checkout ${PETCLINIC_TAG} &&
      git reset --hard)
 
-WRAPPER_JAR=${PROJECT_DIR}/.mvn/wrapper/maven-wrapper.jar
-MAVEN_COMMAND="-classpath ${WRAPPER_JAR} \
-                  -Dmaven.home=${M2_CACHE}
-                  -Dmaven.repo.local=${M2_CACHE} \
-                  -Dmaven.repo.local=${M2_CACHE} \
-                  -Dmaven.multiModuleProjectDirectory=${PROJECT_DIR} \
-                  org.apache.maven.wrapper.MavenWrapperMain"
-
-DOCKER_OPTS="--rm --tmpfs /tmp:exec \
+# We should replace Temurin with our dev container
+DOCKER_OPTS="--rm  \
+    --tmpfs /tmp:exec \
+    -u app \
     -v ${M2_CACHE}:${M2_CACHE} \
     -v ${TEST_DIR}:${TEST_DIR} \
-    -w ${TEST_DIR}/spring-petclinic\
-    -u app"
-
-# add shell to allow maven tests
-cp /bin/sh sh
-docker build --build-arg BASE_IMAGE=${BASE_IMAGE:-ubuntu/jre:17_edge} \
-    -t ${PETCLINIC_TAG} .
-
-# We should replace Temurin with our dev container
-docker run \
-    ${DOCKER_OPTS} \
-    ${BUILD_IMAGE} \
-    java \
-    ${MAVEN_COMMAND} \
-    -q test-compile
+    -w ${TEST_DIR}/${APP} "
 
 # now run the tests within our container
 docker run \
     ${DOCKER_OPTS} \
-    ${PETCLINIC_TAG} \
-    ${MAVEN_COMMAND} \
-    test
+    ${MAVEN_IMAGE} \
+        -Dmaven.repo.local="${M2_CACHE}" \
+        test


### PR DESCRIPTION
This PR is waiting on https://github.com/ubuntu-rocks/chiselled-jre/pull/103

- Update container tags to Java 17
- Use git repository instead of downloading code for pdfbox
- Simplify spring petclinic tests
- Update pdfbox and spring petclinic tags to Java 17 versions